### PR TITLE
add new -cbh8 mode

### DIFF
--- a/common.h
+++ b/common.h
@@ -52,6 +52,7 @@ typedef struct {
   String  verbose_option;
   String  fork_option;
   String  buttonup_option;
+  String  cbh8_option;
   String  kill;
   int     pause;
   int     debug; 
@@ -62,6 +63,7 @@ typedef struct {
   int     length;
   int     own_selection;
   int     buttonup;
+  int     cbh8;
 } OptionsRec;
 
 extern Widget box;


### PR DESCRIPTION

Hello,

I love autocutsel...  Thanks!

It fixed my VNC problem.  I've recently hacked it to fix a different problem that has been bugging me for a while.  Here's a description of the problem:

I mostly use Xterm and Firefox.  I will frequently use the mouse to select some text in an Xterm that I want to Google for in Firefox.  However, the selected text is not a perfectly formed Google query.  Maybe I want to prepend 'inurl:' or enclose it in quotes (or whatever).  So...

I set cursor focus in to the text field of the browser and do a little typing.  When I'm ready to paste the text, I use Firefox's hotkey for paste (so that I do not need to grab the mouse again).

Sacré bleu!!         :smile_cat: 

Firefox has pasted the wrong thing!  I get whatever was lingering around in the CLIPBOARD selection...

I hate the CLIPBOARD and wish it would just go away!

That's what my diff (attached) takes care of.

Now I just run autocutsel with a new option (-cbh8):

    autocutsel -buttonup -fork -cbh8

... and Voilà!

Bye bye CLIPBOARD!  Don't let the door hit you on the way out!

I'm happy now but I thought maybe other people would enjoy this as well so I'm sending the diff to you for your consideration.  Perhaps you are willing to include it "upstream"...

Thanks again,

PS - I initially tried running two instances like so:

    autocutsel -buttonup -fork -selection PRIMARY
    autocutsel -buttonup -fork -selection CLIPBOARD

But running this way had a pesky side affect of clearing my Xterm selection immediately after making it because autocutsel would take ownership of the PRIMARY and Xterm clears its selection when it loses ownership.  Plus running that way is a "heavier" solution...


