### PR TITLE
Fix XA_TARGETS allocation size

### DIFF
--- a/common.c
+++ b/common.c
@@ -91,7 +91,7 @@ Boolean ConvertSelection(Widget w, Atom *selection, Atom *target,
     
     XmuConvertStandardSelection(w, req->time, selection, target, type,
         &std_targets, &std_length, format);
-    *value = XtMalloc(sizeof(Atom)*(std_length + 4));
+    *value = XtMalloc(sizeof(Atom)*(std_length + 5));
     targetP = *(Atom**)value;
     atoms = targetP;
     *length = std_length + 5;


### PR DESCRIPTION
Hi there,

I've found an off-by-one in the commit that adds support for UTF-8 strings, 
94db0b6.  The overflow lead to a crash on OpenBSD with strict malloc
settings.

[This fix is used since 2017 in the OpenBSD ports tree](https://cvsweb.openbsd.org/cgi-bin/cvsweb/ports/x11/autocutsel/patches/patch-common_c?annotate=1.1) 