### PR TITLE
support for specifying client-side character encoding

### DIFF
--- a/common.h
+++ b/common.h
@@ -60,8 +60,11 @@ typedef struct {
   Atom    selection;
   char*   value;
   int     length;
+  char*   org_value;
+  int     org_length;
   int     own_selection;
   int     buttonup;
+  char*   encoding;
 } OptionsRec;
 
 extern Widget box;


### PR DESCRIPTION
On windows copying text is garbled due to different encoding than Linux. I use libiconv to convert the encoding for compatibility, and add the encoding parameter to specify the client encoding format.